### PR TITLE
Fix for multi-python systems.

### DIFF
--- a/install_pepper_deps.sh
+++ b/install_pepper_deps.sh
@@ -49,7 +49,7 @@ echo "installing Cheetah template library"
 $TAR Cheetah-2.4.4.tar.gz
 cd Cheetah-2.4.4
 export PYTHONPATH=${DEPS_DIR}/lib/python/:${PYTHONPATH}
-python setup.py install --home $DEPS_DIR
+python2.7 setup.py install --home $DEPS_DIR
 cd $UP
 
 # GMPMEE


### PR DESCRIPTION
Very simple fix for systems that have multiple versions of Python installed. A lot of recent flavours of Linux don't ship with Python2.\* any more so this code won't run as intended.

If I have time I might build a vagrant environment that includes pepper, libsnark, snarkfront, etc so that devs can start playing with this software without the painful build process. Software this complex really needs a fixed environment with packages pre-installed otherwise potential devs will be scared away from all the errors.

Cool software, btw.
